### PR TITLE
Fix confidence parsing for progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,14 @@
             document.getElementById('selling-tips').textContent = result.selling_tips || 'Professional photography and detailed descriptions recommended';
 
             // Handle confidence score
-            const confidence = parseFloat(result.confidence) || 0.75;
+            let confidence = parseFloat(result.confidence);
+            if (isNaN(confidence)) {
+                confidence = 0.75;
+            }
+            if (confidence > 1) {
+                confidence = confidence / 100;
+            }
+            confidence = Math.min(confidence, 1);
             document.getElementById('confidence-text').textContent = Math.round(confidence * 100) + '%';
             document.getElementById('confidence-bar').style.width = (confidence * 100) + '%';
 


### PR DESCRIPTION
## Summary
- handle confidence strings over 1 so progress bar does not overflow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f2f930da48323952e8701275c441e