### PR TITLE
Add jest tests and script

### DIFF
--- a/netlify/functions/analyze.test.js
+++ b/netlify/functions/analyze.test.js
@@ -1,0 +1,49 @@
+const path = require('path');
+
+describe('analyze function', () => {
+  const event = {
+    httpMethod: 'POST',
+    body: JSON.stringify({ imageBase64: 'imgdata', prompt: 'Hi' })
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('returns 500 status when OPENAI_API_KEY is missing', async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    jest.doMock('openai', () => {
+      return jest.fn().mockImplementation(() => ({
+        chat: { completions: { create: jest.fn() } }
+      }));
+    });
+
+    const { handler } = require('./analyze');
+    const response = await handler(event, {});
+    expect(response.statusCode).toBe(500);
+  });
+
+  test('returns 200 and JSON when OpenAI mock returns a message', async () => {
+    process.env.OPENAI_API_KEY = 'key';
+
+    const createMock = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: 'analysis' } }],
+      usage: { total_tokens: 1 }
+    });
+
+    jest.doMock('openai', () => {
+      return jest.fn().mockImplementation(() => ({
+        chat: { completions: { create: createMock } }
+      }));
+    });
+
+    const { handler } = require('./analyze');
+    const response = await handler(event, {});
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      result: 'analysis',
+      usage: { total_tokens: 1 }
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,5 +3,11 @@
   "version": "1.0.0",
   "dependencies": {
     "openai": "^4.0.0"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `jest` as a dev dependency and npm test script
- create unit tests for Netlify analyze function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4142ecfc8323acc89f723cf9368c